### PR TITLE
Fix word count, add more stats

### DIFF
--- a/bin/main.dart
+++ b/bin/main.dart
@@ -44,12 +44,15 @@ void main(List<String> args) async {
   print([
     'Name',
     'Is Widget',
-    'Has Code Snippet',
-    'Has DartPad',
+    'Has Code',
+    'Has Snippet Sample',
+    'Has Application Sample',
+    'Has DartPad Sample',
     'Has YouTube',
     'Reference Count',
     'Link Count',
-    'Line Count',
+    'Prose Line Count',
+    'Code Line Count',
     'Word Count',
     'Char Count'
   ].join(','));
@@ -58,11 +61,14 @@ void main(List<String> args) async {
       item.elementName,
       item.isWidget,
       item.hasCodeSnippet,
-      item.hasDartPad,
+      item.hasSnippetSample,
+      item.hasApplicationSample,
+      item.hasDartPadSample,
       item.hasYouTube,
       item.referenceCount,
       item.linkCount,
       item.lineCount,
+      item.codeLineCount,
       item.wordCount,
       item.charCount
     ].join(','));

--- a/test/doc_surveyor_test.dart
+++ b/test/doc_surveyor_test.dart
@@ -8,7 +8,7 @@ void main() {
     test('doc comment metrics', () {
       var docData = DocData('Flow', true, docCommentGood);
       expect(docData.hasYouTube, isFalse);
-      expect(docData.hasDartPad, isTrue);
+      expect(docData.hasDartPadSample, isTrue);
       expect(docData.referenceCount, equals(13));
       expect(docData.hasCodeSnippet, true);
     });


### PR DESCRIPTION
Hi John!

I updated this with some code from my snippets package that strips out the code from the comments so that the word count is just prose, as well as some other stats (code line count, separate counts for the different types of samples).

-Greg.